### PR TITLE
Don't send notification to all followers for private tags

### DIFF
--- a/src/Listeners/SendNotificationWhenDiscussionIsStarted.php
+++ b/src/Listeners/SendNotificationWhenDiscussionIsStarted.php
@@ -44,7 +44,7 @@ class SendNotificationWhenDiscussionIsStarted
         $tags = $discussion->tags;
         $tagIds = $tags->map->id;
 
-        if ($tags->isEmpty()) {
+        if ($tags->isEmpty() || !$event->actor->can('viewPrivate', $discussion)) {
             return;
         }
 


### PR DESCRIPTION
Fix for not sending notifications to all tag followers for private discussion.