### PR TITLE
Dk/query optimization

### DIFF
--- a/src/Listeners/AddTagSubscriptionAttribute.php
+++ b/src/Listeners/AddTagSubscriptionAttribute.php
@@ -19,9 +19,9 @@ class AddTagSubscriptionAttribute
 {
     public function handle(Serializing $event)
     {
-        if ($event->isSerializer(TagSerializer::class)
-            && ($state = $event->model->stateFor($event->actor))) {
-            $event->attributes['subscription'] = $state->subscription;
+        if ($event->isSerializer(TagSerializer::class)) {
+            $event->attributes['subscription'] = $event->model->state['subscription'];
+//            $event->attributes['subscription'] = $state->subscription;
         }
 
         if ($event->isSerializer(DiscussionSerializer::class)) {

--- a/src/Listeners/AddTagSubscriptionAttribute.php
+++ b/src/Listeners/AddTagSubscriptionAttribute.php
@@ -20,9 +20,13 @@ class AddTagSubscriptionAttribute
     public function handle(Serializing $event)
     {
         if ($event->isSerializer(TagSerializer::class)) {
-            $state = $event->model->state ?? $event->model->stateFor($event->actor) ?? [];
+            if (isset($event->model->state)) {
+                $state = $event->model->state;
+            } else {
+                $state = $event->model->stateFor($event->actor);
+            }
 
-            $event->attributes['subscription'] = Arr::get($state, 'subscription');
+            $event->attributes['subscription'] = Arr::get($state ?? [], 'subscription');
         }
     }
 }

--- a/src/Listeners/AddTagSubscriptionAttribute.php
+++ b/src/Listeners/AddTagSubscriptionAttribute.php
@@ -20,13 +20,11 @@ class AddTagSubscriptionAttribute
     public function handle(Serializing $event)
     {
         if ($event->isSerializer(TagSerializer::class)) {
-            if (isset($event->model->state)) {
-                $state = $event->model->state;
-            } else {
-                $state = $event->model->stateFor($event->actor);
+            if (!isset($event->model->state)) {
+                $event->model->state = $event->model->stateFor($event->actor);
             }
 
-            $event->attributes['subscription'] = Arr::get($state ?? [], 'subscription');
+            $event->attributes['subscription'] = Arr::get($event->model->state ?? [], 'subscription');
         }
     }
 }

--- a/src/Listeners/AddTagSubscriptionAttribute.php
+++ b/src/Listeners/AddTagSubscriptionAttribute.php
@@ -13,13 +13,16 @@ namespace FoF\FollowTags\Listeners;
 
 use Flarum\Api\Event\Serializing;
 use Flarum\Tags\Api\Serializer\TagSerializer;
+use Illuminate\Support\Arr;
 
 class AddTagSubscriptionAttribute
 {
     public function handle(Serializing $event)
     {
         if ($event->isSerializer(TagSerializer::class)) {
-            $event->attributes['subscription'] = $event->model->state['subscription'];
+            $state = $event->model->state ?? $event->model->stateFor($event->actor) ?? [];
+
+            $event->attributes['subscription'] = Arr::get($state, 'subscription');
         }
     }
 }

--- a/src/Listeners/AddTagSubscriptionAttribute.php
+++ b/src/Listeners/AddTagSubscriptionAttribute.php
@@ -12,7 +12,6 @@
 namespace FoF\FollowTags\Listeners;
 
 use Flarum\Api\Event\Serializing;
-use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Tags\Api\Serializer\TagSerializer;
 
 class AddTagSubscriptionAttribute
@@ -21,11 +20,6 @@ class AddTagSubscriptionAttribute
     {
         if ($event->isSerializer(TagSerializer::class)) {
             $event->attributes['subscription'] = $event->model->state['subscription'];
-//            $event->attributes['subscription'] = $state->subscription;
-        }
-
-        if ($event->isSerializer(DiscussionSerializer::class)) {
-//            throw new \Error(json_encode($event->model->tags->map->state->map->subscription));
         }
     }
 }

--- a/src/Listeners/HideDiscussionsInIgnoredTags.php
+++ b/src/Listeners/HideDiscussionsInIgnoredTags.php
@@ -24,13 +24,19 @@ class HideDiscussionsInIgnoredTags
 
         $user = $event->criteria->actor;
 
-        $event->search->getQuery()
-            ->whereNotExists(function ($query) use ($user) {
-                $hide = TagState::where('user_id', $user->id)->where('subscription', 'hide')->pluck('tag_id');
+        $db = $event->search->getQuery()->getConnection();
 
+        $event->search->getQuery()
+            ->whereNotExists(function ($query) use ($db, $user) {
                 return $query->selectRaw('1')
                     ->from('discussion_tag')
-                    ->whereIn('tag_id', $hide)
+                    ->whereIn('tag_id', function ($query) use ($db, $user) {
+                        $query
+                            ->select($db->raw(1))
+                            ->from((new TagState)->getTable())
+                            ->where('user_id', $user->id)
+                            ->where('subscription', 'hide');
+                    })
                     ->whereColumn('discussions.id', 'discussion_id');
             });
     }

--- a/src/Listeners/HideDiscussionsInIgnoredTags.php
+++ b/src/Listeners/HideDiscussionsInIgnoredTags.php
@@ -33,7 +33,7 @@ class HideDiscussionsInIgnoredTags
                     ->whereIn('tag_id', function ($query) use ($db, $user) {
                         $query
                             ->select($db->raw(1))
-                            ->from((new TagState)->getTable())
+                            ->from((new TagState())->getTable())
                             ->where('user_id', $user->id)
                             ->where('subscription', 'hide');
                     })


### PR DESCRIPTION
This reduces the number of queries drastically. This listener is executed for each tag and all tags are loaded when the Forum index is rendered. This causes 400 queries if the forum has 400 tags.