### PR TITLE
Query optimalisation 2

### DIFF
--- a/src/Listeners/AddTagSubscriptionAttribute.php
+++ b/src/Listeners/AddTagSubscriptionAttribute.php
@@ -20,10 +20,6 @@ class AddTagSubscriptionAttribute
     public function handle(Serializing $event)
     {
         if ($event->isSerializer(TagSerializer::class)) {
-            if (!isset($event->model->state)) {
-                $event->model->state = $event->model->stateFor($event->actor);
-            }
-
             $event->attributes['subscription'] = Arr::get($event->model->state ?? [], 'subscription');
         }
     }


### PR DESCRIPTION
The tag state is eager loaded; if the state is `null` the actor has no existing tag state entry `tag_user`. We really need to forgo reading the state here, no matter your objections. I don't understand why you had a `get property of non object error` @datitisev can you test this out?

Edit: maybe that error popped up for guests, the current `Arr::get` code negates that issue.