### PR TITLE
Fixed typo in HideDiscussionInIgnoredTags listener. (#23)

### DIFF
--- a/src/Listeners/HideDiscussionsInIgnoredTags.php
+++ b/src/Listeners/HideDiscussionsInIgnoredTags.php
@@ -23,21 +23,17 @@ class HideDiscussionsInIgnoredTags
         }
 
         $user = $event->criteria->actor;
-
-        $db = $event->search->getQuery()->getConnection();
-
         $event->search->getQuery()
-            ->whereNotExists(function ($query) use ($db, $user) {
-                return $query->selectRaw('1')
+            ->whereNotIn('discussions.id', function ($query) use ($user) {
+                return $query->select('discussion_id')
                     ->from('discussion_tag')
-                    ->whereIn('tag_id', function ($query) use ($db, $user) {
+                    ->whereIn('tag_id', function ($query) use ($user) {
                         $query
-                            ->select($db->raw(1))
+                            ->select('tag_id')
                             ->from((new TagState())->getTable())
                             ->where('user_id', $user->id)
                             ->where('subscription', 'hide');
-                    })
-                    ->whereColumn('discussions.id', 'discussion_id');
+                    });
             });
     }
 }


### PR DESCRIPTION
Hidden discussion tag filter wasn't working due to using $db->raw(1) instead of select('tag_id'):
`                    ->whereIn('tag_id', function ($query) use ($user) {
                        $query->select($db->raw(1))
`

