### PR TITLE
Improve performance by using eager loaded actor tag state

### DIFF
--- a/src/AddTagSubscriptionAttribute.php
+++ b/src/AddTagSubscriptionAttribute.php
@@ -18,7 +18,7 @@ class AddTagSubscriptionAttribute
 {
     public function __invoke(TagSerializer $serializer, Tag $tag, array $attributes): array
     {
-        $state = $tag->stateFor($serializer->getActor());
+        $state = $tag->state;
 
         $attributes['subscription'] = $state->subscription;
 


### PR DESCRIPTION
Currently for every tag, the tag state with the actor us queried separately, resulting in many many queries in busy forums.

**Changes proposed in this pull request:**
This PR changes the code so that an already eager loaded state is used.

**Reviewers should focus on:**
Before Flarum 1.0, the tags extension already eager loaded the tag state, but with a refactor done for 1.0, that was lost, so this PR will rely on that being recovered, so this can only be merged for a Flarum version containing that change. See relevant tags extension PR link below.

**Screenshot**
Before | After
-- | --
![Screenshot from 2021-08-24 10-59-08](https://user-images.githubusercontent.com/20267363/130597516-c496b949-370c-4a06-9356-641e46f9d272.png) | ![Screenshot from 2021-08-24 10-59-16](https://user-images.githubusercontent.com/20267363/130597593-e2efe2ce-ebe5-4c88-ae0c-ecc4fc133d2f.png)

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [x] Related [Flarum core extension PR's]: https://github.com/flarum/tags/pull/143
