### PR TITLE
fix: avoid errors if flarum subscriptions isn't enabled

### DIFF
--- a/js/src/forum/utils/isFollowingPage.js
+++ b/js/src/forum/utils/isFollowingPage.js
@@ -1,3 +1,7 @@
 import app from 'flarum/forum/app';
 
-export default () => m.route.get().includes(app.route('following'));
+export default () => {
+    if (!app.initializers.has('subscriptions')) return;
+
+    return m.route.get().includes(app.route('following'));
+}


### PR DESCRIPTION
This isn't extremely robust, as the initializer key name could change at any point and isn't really considered public API. But without this, tags don't currently load.
