### PR TITLE
Add timestamps to `tag_user`

### DIFF
--- a/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
+++ b/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
@@ -9,18 +9,27 @@
  * file that was distributed with this source code.
  */
 
-use Flarum\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
 
-return Migration::addColumns('tag_user', [
-    'created_at' => [
-        'timestamp',
-        'useCurrent' => true,
-        'nullable'   => true,
-    ],
-    'updated_at' => [
-        'timestamp',
-        'useCurrent'         => true,
-        'useCurrentOnUpdate' => true,
-        'nullable'           => true,
-    ],
-]);
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('tag_user', function (Blueprint $table) {
+            $table->timestamp('created_at')->nullable();
+            $table->timestamp('updated_at')->nullable();
+        });
+
+        // do this manually because dbal doesn't recognize timestamp columns
+        $connection = $schema->getConnection();
+        $prefix = $connection->getTablePrefix();
+        $connection->statement("ALTER TABLE `${prefix}tag_user` MODIFY created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP");
+        $connection->statement("ALTER TABLE `${prefix}tag_user` MODIFY updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP");
+    },
+
+    'down' => function (Builder $schema) {
+        $schema->table('tag_user', function (Blueprint $table) {
+            $table->dropColumn('created_at');
+            $table->dropColumn('updated_at');
+        });
+    }
+];

--- a/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
+++ b/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
@@ -31,5 +31,5 @@ return [
             $table->dropColumn('created_at');
             $table->dropColumn('updated_at');
         });
-    }
+    },
 ];

--- a/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
+++ b/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
@@ -15,10 +15,12 @@ return Migration::addColumns('tag_user', [
     'created_at' => [
         'timestamp',
         'useCurrent' => true,
+        'nullable'   => true,
     ],
     'updated_at' => [
         'timestamp',
         'useCurrent'         => true,
         'useCurrentOnUpdate' => true,
+        'nullable'           => true,
     ],
 ]);

--- a/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
+++ b/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
@@ -18,7 +18,7 @@ return Migration::addColumns('tag_user', [
     ],
     'updated_at' => [
         'timestamp',
-        'useCurrent' => true,
+        'useCurrent'         => true,
         'useCurrentOnUpdate' => true,
     ],
 ]);

--- a/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
+++ b/migrations/2022_05_20_000000_add_timestamps_to_tag_user_table.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of fof/follow-tags.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('tag_user', [
+    'created_at' => [
+        'timestamp',
+        'useCurrent' => true,
+    ],
+    'updated_at' => [
+        'timestamp',
+        'useCurrent' => true,
+        'useCurrentOnUpdate' => true,
+    ],
+]);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Database migration that add timestamps to the `tag_user` table.

The timestamps are not really used anywhere in this extension, but can be very handy for analytics purposes.

This PR is kind of a follow-up of https://github.com/flarum/framework/pull/3435

**Reviewers should focus on:**
The migration runs without error and doesn't cause any unwanted side-effects (including performance aspects).

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
