### PR TITLE
Specify wich table to select data from in join query

### DIFF
--- a/src/Jobs/SendNotificationWhenDiscussionIsReTagged.php
+++ b/src/Jobs/SendNotificationWhenDiscussionIsReTagged.php
@@ -59,6 +59,7 @@ class SendNotificationWhenDiscussionIsReTagged implements ShouldQueue
             return;
         }
 
+        // The `select(...)` part is not mandatory here, but makes the query safer. See #55.
         $notify = User::select('users.*')
             ->where('users.id', '!=', $this->actor->id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')

--- a/src/Jobs/SendNotificationWhenDiscussionIsReTagged.php
+++ b/src/Jobs/SendNotificationWhenDiscussionIsReTagged.php
@@ -59,7 +59,8 @@ class SendNotificationWhenDiscussionIsReTagged implements ShouldQueue
             return;
         }
 
-        $notify = User::where('users.id', '!=', $this->actor->id)
+        $notify = User::select('users.*')
+            ->where('users.id', '!=', $this->actor->id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')
             ->whereIn('tag_user.tag_id', $tagIds->all())
             ->whereIn('tag_user.subscription', ['follow', 'lurk'])

--- a/src/Jobs/SendNotificationWhenDiscussionIsStarted.php
+++ b/src/Jobs/SendNotificationWhenDiscussionIsStarted.php
@@ -53,7 +53,8 @@ class SendNotificationWhenDiscussionIsStarted implements ShouldQueue
             return;
         }
 
-        $notify = User::where('users.id', '!=', $this->discussion->user_id)
+        $notify = User::select('users.*')
+            ->where('users.id', '!=', $this->discussion->user_id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')
             ->whereIn('tag_user.tag_id', $tagIds->all())
             ->whereIn('tag_user.subscription', ['follow', 'lurk'])

--- a/src/Jobs/SendNotificationWhenDiscussionIsStarted.php
+++ b/src/Jobs/SendNotificationWhenDiscussionIsStarted.php
@@ -53,6 +53,7 @@ class SendNotificationWhenDiscussionIsStarted implements ShouldQueue
             return;
         }
 
+        // The `select(...)` part is not mandatory here, but makes the query safer. See #55.
         $notify = User::select('users.*')
             ->where('users.id', '!=', $this->discussion->user_id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')

--- a/src/Jobs/SendNotificationWhenReplyIsPosted.php
+++ b/src/Jobs/SendNotificationWhenReplyIsPosted.php
@@ -60,6 +60,7 @@ class SendNotificationWhenReplyIsPosted implements ShouldQueue
         }
 
         $notify = $this->post->discussion->readers()
+            ->select('users.*')
             ->where('users.id', '!=', $this->post->user_id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')
             ->whereIn('tag_user.tag_id', $tagIds->all())

--- a/src/Jobs/SendNotificationWhenReplyIsPosted.php
+++ b/src/Jobs/SendNotificationWhenReplyIsPosted.php
@@ -60,6 +60,7 @@ class SendNotificationWhenReplyIsPosted implements ShouldQueue
         }
 
         $notify = $this->post->discussion->readers()
+            // The `select(...)` part is not mandatory here, but makes the query safer. See #55.
             ->select('users.*')
             ->where('users.id', '!=', $this->post->user_id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Added a select(...) instruction to queries that join `users` and `tag_user`.

This shouldn't change anything for the extension as it is. But in my case, I have added columns to `tag_user` (using another extension) that would override columns of the `users` table when the join happens because the columns have the same name in both tables. Explicitly telling Laravel what table to select data from (`users`) fixes that issue.

**Reviewers should focus on:**
Nothing is broken. Notifications still go out normally to tag followers.

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**
