### PR TITLE
feat: allow other exts to add to the followPage options

### DIFF
--- a/js/src/common/utils/followingPageOptions.ts
+++ b/js/src/common/utils/followingPageOptions.ts
@@ -6,13 +6,26 @@ type FollowingPageOptions = {
 
 const cache: Record<string, FollowingPageOptions> = {};
 
+// Allow other extensions to add their own options
+const optionProviders: Array<(section: string) => Record<string, string>> = [];
+
+export function addFollowingPageOption(provider: (section: string) => Record<string, string>) {
+  optionProviders.push(provider);
+}
+
 export default function followingPageOptions(section: string): FollowingPageOptions {
   if (!cache[section]) {
+    // Start with default options
     cache[section] = ['none', 'tags'].reduce((o, key) => {
       o[key] = app.translator.trans(`fof-follow-tags.${section}.following_${key}_label`);
 
       return o;
     }, {} as FollowingPageOptions);
+
+    // Add options from other extensions
+    optionProviders.forEach((provider) => {
+      Object.assign(cache[section], provider(section));
+    });
   }
 
   return cache[section];


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
