### PR TITLE
perf: fix N+1 queries in notification jobs and discussion update serialization

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -13,6 +13,7 @@ namespace FoF\FollowTags;
 
 use Flarum\Api\Context;
 use Flarum\Api\Endpoint\Update;
+use Flarum\Api\Resource\DiscussionResource;
 use Flarum\Api\Schema;
 use Flarum\Discussion\Event as Discussion;
 use Flarum\Extend;
@@ -135,4 +136,16 @@ return [
     (new Extend\SearchDriver(\Flarum\Search\Database\DatabaseSearchDriver::class))
         ->addFilter(\Flarum\Discussion\Search\DiscussionSearcher::class, Search\FollowTagsFilter::class)
         ->addMutator(\Flarum\Discussion\Search\DiscussionSearcher::class, Search\HideTagsFilter::class),
+
+    // Eager-load tag state for the actor on discussion updates so the `subscription`
+    // field getter doesn't fall back to per-tag stateFor() queries.
+    // flarum/tags covers Index, Show, and Create — but not Update.
+    (new Extend\ApiResource(DiscussionResource::class))
+        ->endpoint(
+            Update::class,
+            fn (Update $endpoint) => $endpoint->eagerLoadWhere(
+                'tags',
+                fn ($query, Context $context) => $query->withStateFor($context->getActor())
+            )
+        ),
 ];

--- a/src/Jobs/NotificationJob.php
+++ b/src/Jobs/NotificationJob.php
@@ -14,10 +14,12 @@ namespace FoF\FollowTags\Jobs;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\NotificationSyncer;
 use Flarum\Queue\AbstractJob;
+use Flarum\Tags\TagState;
 use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
 
 class NotificationJob extends AbstractJob implements ShouldQueue
 {
@@ -38,5 +40,26 @@ class NotificationJob extends AbstractJob implements ShouldQueue
         /** @var array<User> $users */
         $users = $recipients->all();
         $syncer->sync($blueprint, $users);
+    }
+
+    /**
+     * Pre-load all TagState rows for the given users and tags in a single query.
+     * Returns a collection keyed by user_id for O(1) lookup in reject() callbacks.
+     *
+     * @param BaseCollection $users  Collection of User models
+     * @param BaseCollection $tagIds Collection of tag IDs
+     *
+     * @return BaseCollection<int, BaseCollection>
+     */
+    protected function preloadTagStates(BaseCollection $users, BaseCollection $tagIds): BaseCollection
+    {
+        if ($users->isEmpty()) {
+            return collect();
+        }
+
+        return TagState::whereIn('user_id', $users->pluck('id')->all())
+            ->whereIn('tag_id', $tagIds->all())
+            ->get()
+            ->groupBy('user_id');
     }
 }

--- a/src/Jobs/SendNotificationWhenDiscussionIsReTagged.php
+++ b/src/Jobs/SendNotificationWhenDiscussionIsReTagged.php
@@ -49,18 +49,23 @@ class SendNotificationWhenDiscussionIsReTagged extends NotificationJob
         }
 
         // The `select(...)` part is not mandatory here, but makes the query safer. See #55.
-        $notify = User::select('users.*')
+        $users = User::select('users.*')
             ->where('users.id', '!=', $this->actor->id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')
             ->whereIn('tag_user.tag_id', $tagIds->all())
             ->whereIn('tag_user.subscription', ['follow', 'lurk'])
             ->get()
-            ->unique()
-            ->reject(function ($user) use ($firstPost, $tags) {
-                return $tags->map->stateFor($user)->map->subscription->contains('ignore')
-                        || !$this->discussion->newQuery()->whereVisibleTo($user)->find($this->discussion->id)
-                        || !$firstPost->isVisibleTo($user);
-            });
+            ->unique();
+
+        $tagStates = $this->preloadTagStates($users, $tagIds);
+
+        $notify = $users->reject(function ($user) use ($firstPost, $tagStates) {
+            $subscriptions = $tagStates->get($user->id, collect())->pluck('subscription');
+
+            return $subscriptions->contains('ignore')
+                    || !$this->discussion->newQuery()->whereVisibleTo($user)->find($this->discussion->id)
+                    || !$firstPost->isVisibleTo($user);
+        });
 
         $this->sync(
             $notifications,

--- a/src/Jobs/SendNotificationWhenDiscussionIsStarted.php
+++ b/src/Jobs/SendNotificationWhenDiscussionIsStarted.php
@@ -48,18 +48,23 @@ class SendNotificationWhenDiscussionIsStarted extends NotificationJob
         }
 
         // The `select(...)` part is not mandatory here, but makes the query safer. See #55.
-        $notify = User::select('users.*')
+        $users = User::select('users.*')
             ->where('users.id', '!=', $this->discussion->user_id)
             ->join('tag_user', 'tag_user.user_id', '=', 'users.id')
             ->whereIn('tag_user.tag_id', $tagIds->all())
             ->whereIn('tag_user.subscription', ['follow', 'lurk'])
             ->get()
-            ->unique()
-            ->reject(function ($user) use ($firstPost, $tags) {
-                return $tags->map->stateFor($user)->map->subscription->contains('ignore')
-                        || !$this->discussion->newQuery()->whereVisibleTo($user)->find($this->discussion->id)
-                        || !$firstPost->isVisibleTo($user);
-            });
+            ->unique();
+
+        $tagStates = $this->preloadTagStates($users, $tagIds);
+
+        $notify = $users->reject(function ($user) use ($firstPost, $tagStates) {
+            $subscriptions = $tagStates->get($user->id, collect())->pluck('subscription');
+
+            return $subscriptions->contains('ignore')
+                    || !$this->discussion->newQuery()->whereVisibleTo($user)->find($this->discussion->id)
+                    || !$firstPost->isVisibleTo($user);
+        });
 
         $this->sync($notifications, new NewDiscussionBlueprint($this->discussion, $firstPost), $notify);
     }

--- a/src/Jobs/SendNotificationWhenReplyIsPosted.php
+++ b/src/Jobs/SendNotificationWhenReplyIsPosted.php
@@ -48,7 +48,7 @@ class SendNotificationWhenReplyIsPosted extends NotificationJob
             return;
         }
 
-        $notify = $this->post->discussion->readers()
+        $users = $this->post->discussion->readers()
             // The `select(...)` part is not mandatory here, but makes the query safer. See #55.
             ->select('users.*')
             ->where('users.id', '!=', $this->post->user_id)
@@ -57,11 +57,16 @@ class SendNotificationWhenReplyIsPosted extends NotificationJob
             ->where('tag_user.subscription', 'lurk')
             ->where('discussion_user.last_read_post_number', '>=', $this->lastPostNumber - 1)
             ->get()
-            ->unique()
-            ->reject(function (User $user) use ($tags) {
-                return $tags->map->stateFor($user)->map->subscription->contains('ignore')
-                    || !$this->post->isVisibleTo($user);
-            });
+            ->unique();
+
+        $tagStates = $this->preloadTagStates($users, $tagIds);
+
+        $notify = $users->reject(function (User $user) use ($tagStates) {
+            $subscriptions = $tagStates->get($user->id, collect())->pluck('subscription');
+
+            return $subscriptions->contains('ignore')
+                || !$this->post->isVisibleTo($user);
+        });
 
         $this->sync($notifications, new NewPostBlueprint($this->post), $notify);
     }


### PR DESCRIPTION
## Summary

- **Notification jobs**: `stateFor($user)` was called inside `reject()` callbacks in all three notification job classes — once per user per tag (N×T queries). Replaced with a single `TagState::whereIn()` pre-load via a new `preloadTagStates()` helper on `NotificationJob`, reducing to 1 query regardless of user/tag count.
- **Discussion Update endpoint**: `flarum/tags` eager-loads tag state via `withStateFor()` for `Index`, `Show`, and `Create` on `DiscussionResource` — but not `Update`. The `subscription` field getter was falling back to `stateFor()` per tag on discussion edit responses. Added `eagerLoadWhere('tags', withStateFor(...))` for the `Update` endpoint to close this gap.

## Confirmed via Clockwork

`PATCH /api/discussions/{id}` with 3 tags: **0 `tag_user` state queries** (was 3×, one per tag). Notification job fix is correct by inspection — async queue jobs are not captured in HTTP Clockwork entries.

## What remains unfixed (by design)

`whereVisibleTo($user)` and `isVisibleTo($user)` in `reject()` remain as per-user queries — these cannot be batched without framework changes.